### PR TITLE
do 8c0ad9de377d9156b6c1cc2557d25b1007001fa5 again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,15 +47,6 @@ jobs:
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
 
-      - name: Built version must match the tag
-        run: |
-          built=$(python -m hatch version 2>/dev/null || python -c "import pypana,importlib.metadata as m;                    
-          print(m.version('pypana'))")
-          want="${GITHUB_REF_NAME#v}"
-          [ "$built" = "$want" ] || { echo "::error::built $built != tag $want"; exit 1; }
-        env:
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-
       - name: Check event matches version
         run: |
           if [ "$EVENT" = "release" ] && [ "$PRERELEASE" = "true" ]; then


### PR DESCRIPTION
(the second squash from the same branch introduced this error)